### PR TITLE
Add mixed-selections endpoint, Selection model, and artwork fallback

### DIFF
--- a/Sources/SoundCloud/APIRequest.swift
+++ b/Sources/SoundCloud/APIRequest.swift
@@ -21,6 +21,7 @@ public struct APIRequest<T> {
         case me
         case library
         case stream
+        case mixedSelections
         case whoToFollow
         case followings(String)
         case followers(String)
@@ -64,6 +65,10 @@ public struct APIRequest<T> {
     
     public static func stream() -> APIRequest<Page<Post>> {
         return APIRequest<Page<Post>>(api: .stream)
+    }
+
+    public static func mixedSelections() -> APIRequest<Page<Selection>> {
+        return APIRequest<Page<Selection>>(api: .mixedSelections)
     }
     
     public static func whoToFollow() -> APIRequest<Page<Recommendation>> {
@@ -173,6 +178,7 @@ public struct APIRequest<T> {
         case .me: return "me"
         case .library: return "me/library/all"
         case .stream: return "stream"
+        case .mixedSelections: return "mixed-selections"
         case .whoToFollow: return "me/suggested/users/who_to_follow"
         case .followings(let id): return "users/\(id)/followings"
         case .followers(let id): return "users/\(id)/followers"

--- a/Sources/SoundCloud/Models/AnyItem.swift
+++ b/Sources/SoundCloud/Models/AnyItem.swift
@@ -1,0 +1,39 @@
+//
+//  AnyItem.swift
+//
+
+import Foundation
+
+public enum AnyItem: SoundCloudIdentifiable {
+    case user(User)
+    case playlist(AnyPlaylist)
+
+    public var id: String {
+        switch self {
+        case .user(let user): return user.id
+        case .playlist(let playlist): return playlist.id
+        }
+    }
+}
+
+extension AnyItem: Decodable {
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(String.self, forKey: .kind)
+
+        switch kind {
+        case "user":
+            self = .user(try User(from: decoder))
+        case "playlist", "system-playlist":
+            self = .playlist(try AnyPlaylist(from: decoder))
+        default:
+            throw UnknownKindError(kind: kind)
+        }
+    }
+
+}

--- a/Sources/SoundCloud/Models/Selection.swift
+++ b/Sources/SoundCloud/Models/Selection.swift
@@ -1,0 +1,45 @@
+//
+//  Selection.swift
+//
+
+import Foundation
+
+public struct Selection: Decodable, Identifiable, Hashable {
+
+    public var id: String
+    public var title: String
+    public var description: String?
+    public var items: [AnyItem]
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "urn"
+        case title
+        case description
+        case items
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+
+        // Best-effort decode items so one unexpected entry doesn't break the whole selection.
+        let page = try container.decode(Page<LossyItem>.self, forKey: .items)
+        items = page.collection.compactMap { $0.value }
+    }
+
+    public static func == (lhs: Selection, rhs: Selection) -> Bool { lhs.id == rhs.id }
+    public func hash(into hasher: inout Hasher) { hasher.combine(id) }
+
+}
+
+private struct LossyItem: Decodable {
+
+    let value: AnyItem?
+
+    init(from decoder: Decoder) throws {
+        value = try? AnyItem(from: decoder)
+    }
+
+}

--- a/Sources/SoundCloud/Models/SystemPlaylist.swift
+++ b/Sources/SoundCloud/Models/SystemPlaylist.swift
@@ -29,6 +29,7 @@ public struct SystemPlaylist: Playlist {
         case title
         case description
         case artworkURL = "artwork_url"
+        case calculatedArtworkURL = "calculated_artwork_url"
         case permalinkURL = "permalink_url"
         case isPublic = "public"
         case isPublic2 = "is_public"
@@ -47,6 +48,7 @@ public struct SystemPlaylist: Playlist {
         title = try container.decode(String.self, forKey: .title)
         description = try container.decodeIfPresent(String.self, forKey: .description)
         artworkURL = try container.decodeIfPresent(URL.self, forKey: .artworkURL)
+            ?? container.decodeIfPresent(URL.self, forKey: .calculatedArtworkURL)
         permalinkURL = try container.decode(URL.self, forKey: .permalinkURL)
         
         let rawIsPublic = try? container.decode(Bool.self, forKey: .isPublic)


### PR DESCRIPTION
Two small additions to support a Discover/home feed in the Nuage app (PR coming separately at lbrndnr/nuage-macos).

## What's in here

**`Selection` model + `mixed-selections` endpoint** (`610b689`): adds `APIRequest.mixedSelections()` hitting `GET /mixed-selections`, which returns the rows you see on soundcloud.com/discover ("More of what you like", "Recently Played", "Mixed for you", etc.). Each `Selection` row contains a heterogeneous list of playlists (both `system-playlist` and `playlist` kinds), decoded via the existing `AnyPlaylist` discriminator, so no new union type was needed.

**Fall back to `calculated_artwork_url`** (`6645ec6`): for personalized system playlists (e.g. "Related tracks: ..."), the API returns `artwork_url: null` and only populates `calculated_artwork_url`. The decoder now falls back to it so these playlists render with artwork. Useful beyond just mixed-selections, any caller of `SystemPlaylist` benefits.